### PR TITLE
Local Branch Test - Remote Compaction Stress Test

### DIFF
--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -422,7 +422,10 @@ DECLARE_string(file_temperature_age_thresholds);
 DECLARE_bool(allow_trivial_copy_when_change_temperature);
 DECLARE_uint32(commit_bypass_memtable_one_in);
 DECLARE_bool(track_and_verify_wals);
-DECLARE_bool(enable_remote_compaction);
+DECLARE_int32(remote_compaction_worker_threads);
+DECLARE_uint64(remote_compaction_worker_interval);
+DECLARE_uint64(remote_compaction_wait_interval);
+DECLARE_uint64(remote_compaction_wait_timeout);
 DECLARE_bool(auto_refresh_iterator_with_snapshot);
 DECLARE_uint32(memtable_op_scan_flush_trigger);
 DECLARE_uint32(memtable_avg_op_scan_flush_trigger);
@@ -754,6 +757,8 @@ inline void SanitizeDoubleParam(double* param) {
 void PoolSizeChangeThread(void* v);
 
 void DbVerificationThread(void* v);
+
+void RemoteCompactionWorkerThread(void* v);
 
 void CompressedCacheSetCapacityThread(void* v);
 

--- a/db_stress_tool/db_stress_compaction_service.h
+++ b/db_stress_tool/db_stress_compaction_service.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "db_stress_shared_state.h"
+#include "db_stress_tool/db_stress_common.h"
 #include "rocksdb/options.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -12,28 +14,71 @@ namespace ROCKSDB_NAMESPACE {
 // Service to simulate Remote Compaction in Stress Test
 class DbStressCompactionService : public CompactionService {
  public:
-  explicit DbStressCompactionService() {}
+  explicit DbStressCompactionService(const std::string& db_path,
+                                     SharedState* shared)
+      : db_path_(db_path), shared_(shared) {}
 
   static const char* kClassName() { return "DbStressCompactionService"; }
 
   const char* Name() const override { return kClassName(); }
 
   CompactionServiceScheduleResponse Schedule(
-      const CompactionServiceJobInfo& /*info*/,
-      const std::string& /*compaction_service_input*/) override {
+      const CompactionServiceJobInfo& info,
+      const std::string& compaction_service_input) override {
+    std::string job_id = info.db_id + "_" + info.db_session_id + "_" +
+                         std::to_string(info.job_id);
+    shared_->EnqueueRemoteCompaction(job_id, info, compaction_service_input);
     CompactionServiceScheduleResponse response(
-        "Implement Me", CompactionServiceJobStatus::kUseLocal);
+        job_id, CompactionServiceJobStatus::kSuccess);
     return response;
   }
 
-  CompactionServiceJobStatus Wait(const std::string& /*scheduled_job_id*/,
-                                  std::string* /*result*/) override {
-    // TODO - Implement
-    return CompactionServiceJobStatus::kUseLocal;
+  CompactionServiceJobStatus Wait(const std::string& scheduled_job_id,
+                                  std::string* result) override {
+    auto start = Env::Default()->NowMicros();
+    while (Env::Default()->NowMicros() - start <
+           FLAGS_remote_compaction_wait_timeout) {
+      if (shared_->GetRemoteCompactionResult(scheduled_job_id, result).ok()) {
+        return CompactionServiceJobStatus::kSuccess;
+      }
+      Env::Default()->SleepForMicroseconds(
+          FLAGS_remote_compaction_wait_interval);
+    }
+    return CompactionServiceJobStatus::kFailure;
+  }
+
+  void OnInstallation(const std::string& scheduled_job_id,
+                      CompactionServiceJobStatus /*status*/) override {
+    // Clean up tmp directory
+    std::string serialized;
+    CompactionServiceResult result;
+    if (shared_->GetRemoteCompactionResult(scheduled_job_id, &serialized)
+            .ok()) {
+      if (CompactionServiceResult::Read(serialized, &result).ok()) {
+        std::vector<std::string> filenames;
+        Status s = Env::Default()->GetChildren(result.output_path, &filenames);
+        for (size_t i = 0; s.ok() && i < filenames.size(); ++i) {
+          s = Env::Default()->DeleteFile(result.output_path + "/" +
+                                         filenames[i]);
+          if (!s.ok()) {
+            // TODO - Handle clean up failure?
+            break;
+          }
+        }
+        if (s.ok()) {
+          Env::Default()->DeleteDir(result.output_path).PermitUncheckedError();
+        }
+      }
+      shared_->RemoveRemoteCompactionResult(scheduled_job_id);
+    }
   }
 
   // TODO - Implement
   void CancelAwaitingJobs() override {}
+
+ private:
+  std::string db_path_;
+  SharedState* shared_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -844,8 +844,22 @@ DEFINE_bool(track_and_verify_wals,
             ROCKSDB_NAMESPACE::Options().track_and_verify_wals,
             "See Options::track_and_verify_wals");
 
-DEFINE_bool(enable_remote_compaction, false,
-            "Enable (simulated) Remote Compaction");
+DEFINE_int32(
+    remote_compaction_worker_threads, 2,
+    "Remote Compaction Worker Thread count. If 0, remote compaction is "
+    "disabled");
+
+DEFINE_uint64(remote_compaction_worker_interval, 10 * 1000,
+              "Remote Compaction Worker Thread dequeue tasks every N "
+              "microseconds. (Default: 10ms)");
+
+DEFINE_uint64(
+    remote_compaction_wait_interval, 10 * 1000,
+    "Remote Compaction Wait() interval in microseconds. (Default: 10ms)");
+
+DEFINE_uint64(
+    remote_compaction_wait_timeout, 30 * 1000 * 1000,
+    "Remote Compaction Wait() Timeout in microseconds. (Default: 30 seconds)");
 
 DEFINE_uint32(ingest_wbwi_one_in, 0,
               "If set, will call"

--- a/db_stress_tool/db_stress_shared_state.h
+++ b/db_stress_tool/db_stress_shared_state.h
@@ -276,6 +276,53 @@ class SharedState {
     return expected_state_manager_->GetPersistedSeqno();
   }
 
+  void EnqueueRemoteCompaction(const std::string& job_id,
+                               const CompactionServiceJobInfo& job_info,
+                               const std::string& serialized_input) {
+    MutexLock l(&remote_compaction_queue_mu_);
+    remote_compaction_queue_.emplace(job_id, job_info, serialized_input);
+  }
+
+  bool DequeueRemoteCompaction(std::string* job_id,
+                               CompactionServiceJobInfo* job_info,
+                               std::string* serialized_input) {
+    assert(job_id);
+    assert(job_info);
+    assert(serialized_input);
+    MutexLock l(&remote_compaction_queue_mu_);
+    if (!remote_compaction_queue_.empty()) {
+      const auto [id, info, input] = remote_compaction_queue_.front();
+      *job_id = id;
+      *job_info = info;
+      *serialized_input = input;
+      remote_compaction_queue_.pop();
+      return true;
+    }
+    return false;
+  }
+
+  void AddRemoteCompactionResult(const std::string& job_id,
+                                 const std::string& result) {
+    MutexLock l(&remote_compaction_result_map_mu_);
+    remote_compaction_result_map_.emplace(job_id, result);
+  }
+
+  Status GetRemoteCompactionResult(const std::string& job_id,
+                                   std::string* result) {
+    MutexLock l(&remote_compaction_result_map_mu_);
+    if (remote_compaction_result_map_.find(job_id) !=
+        remote_compaction_result_map_.end()) {
+      *result = remote_compaction_result_map_.at(job_id);
+      return Status::OK();
+    }
+    return Status::NotFound();
+  }
+
+  void RemoveRemoteCompactionResult(const std::string& job_id) {
+    MutexLock l(&remote_compaction_result_map_mu_);
+    remote_compaction_result_map_.erase(job_id);
+  }
+
   // Prepare a Put that will be started but not finish yet
   // This is useful for crash-recovery testing when the process may crash
   // before updating the corresponding expected value
@@ -429,6 +476,16 @@ class SharedState {
   StressTest* stress_test_;
   std::atomic<bool> verification_failure_;
   std::atomic<bool> should_stop_test_;
+
+  // Queue for the remote compaction. Tuple of job id, job info and serialized
+  // compaction_service_input
+  port::Mutex remote_compaction_queue_mu_;
+  std::queue<std::tuple<std::string, CompactionServiceJobInfo, std::string>>
+      remote_compaction_queue_;
+  // Result Map for the remote compaciton. Key is the scheduled_job_id and value
+  // is serialized compaction_service_result
+  port::Mutex remote_compaction_result_map_mu_;
+  std::unordered_map<std::string, std::string> remote_compaction_result_map_;
 
   // Keys that should not be overwritten
   const std::unordered_set<int64_t> no_overwrite_ids_;

--- a/db_stress_tool/db_stress_test_base.h
+++ b/db_stress_tool/db_stress_test_base.h
@@ -53,6 +53,7 @@ class StressTest {
     Status s = db_->EnableAutoCompaction(column_families_);
     return s;
   }
+  Options GetOptions(int cf_id);
   void CleanUp();
 
  protected:

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -498,6 +498,7 @@ struct CompactionServiceJobInfo {
   // the output level of the compaction.
   int output_level;
 
+  CompactionServiceJobInfo() {}
   CompactionServiceJobInfo(std::string db_name_, std::string db_id_,
                            std::string db_session_id_, uint32_t cf_id_,
                            std::string cf_name_, uint64_t job_id_,

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -343,7 +343,7 @@ default_params = {
     "universal_max_read_amp": lambda: random.choice([-1] * 3 + [0, 4, 10]),
     "paranoid_memory_checks": lambda: random.choice([0] * 7 + [1]),
     "allow_unprepared_value": lambda: random.choice([0, 1]),
-    "enable_remote_compaction": lambda: random.choice([0, 1]),
+    "remote_compaction_worker_threads": lambda: random.choice([0, 4]),
     "auto_refresh_iterator_with_snapshot": lambda: random.choice([0, 1]),
     "memtable_op_scan_flush_trigger": lambda: random.choice([0, 10, 100, 1000]),
     "memtable_avg_op_scan_flush_trigger": lambda: random.choice([0, 2, 20, 200]),


### PR DESCRIPTION
# Summary

Simulate Remote Compaction in Stress Test by running a separate set of threads that runs remote compaction. 
Queue and ResultMap for the remote compactions are stored in memory as part of the `SharedState`. They are shared across main worker threads and remote compaction worker threads.

`enable_remote_compaction` is replaced by `remote_compaction_worker_threads`. 
If `remote_compaction_worker_threads` is set to 0, remote compaction is not enabled in Stress Test.

# Test Plan

```
./db_stress --remote_compaction_worker_threads=4  --flush_one_in=1000 --writepercent=40 --readpercent=40 --iterpercent=10 --prefixpercent=0 --delpercent=10 --destroy_db_initially=0 --clear_column_family_one_in=0 --reopen=0
```
```
python3 -u tools/db_crashtest.py blackbox --remote_compaction_worker_threads=8
```